### PR TITLE
Add support for retrieving the password from the system keyring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+
+0.2 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~
+
++ `#1`_: Add support for retrieving the DataCite API password from the
+  system keyring.
+
++ Update the XML schema url for DataCite metadata to version 4.4
+
+.. _#1: https://github.com/RKrahl/datacite/pull/1
+
+
 0.1 (2022-11-25)
 ~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Python:
 Required library packages:
 
 + `setuptools`_
++ `keyring`_
 + `lxml`_
 + `Requests`_
 + `PyYAML`_
@@ -54,6 +55,7 @@ permissions and limitations under the License.
 .. _DataCite REST API: https://support.datacite.org/docs/api
 .. _Helmholtz-Zentrum Berlin für Materialien und Energie: https://www.helmholtz-berlin.de/
 .. _setuptools: https://github.com/pypa/setuptools/
+.. _keyring: https://pypi.org/project/keyring/
 .. _lxml: https://lxml.de/
 .. _Requests: https://requests.readthedocs.io/
 .. _PyYAML: https://github.com/yaml/pyyaml

--- a/python-datacite.spec
+++ b/python-datacite.spec
@@ -13,6 +13,7 @@ BuildRequires:	python3-setuptools
 Requires:	python3-PyYAML
 Requires:	python3-lxml
 Requires:	python3-requests
+Requires:	python3-keyring
 BuildArch:	noarch
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build
 

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,6 @@ setup(
     packages = ["datacite"],
     scripts = ["scripts/datacite-doi.py"],
     python_requires = ">=3.4",
-    install_requires = ["lxml", "requests", "PyYAML"],
+    install_requires = ["keyring", "lxml", "requests", "PyYAML"],
     cmdclass = dict(build_py=build_py, sdist=sdist, meta=meta),
 )


### PR DESCRIPTION
Add support for retrieving the password from the system keyring. This requires [keyring](https://pypi.org/project/keyring/) as a third party library package and is able to retrieve the password from any backend supported by that package, such as KWallet. As a result  (if authentication is needed in the first place), the password will be retrieved from the following places in order: command line argument, configuration file, system keyring, interactive query from the user. First match wins.