### PR TITLE
Add datacite-validate-xml.py command line script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,9 +8,14 @@ Changelog
 + `#1`_: Add support for retrieving the DataCite API password from the
   system keyring.
 
-+ Update the XML schema url for DataCite metadata to version 4.4
++ `#2`_: Add :ref:`datacite-validate-xml` command line script.
+  :class:`datacite.xml.XML` raises :exc:`lxml.etree.DocumentInvalid`
+  instead of :exc:`ValueError` if the metadata fails to validate.
+
++ Update the XML schema url for DataCite metadata to version 4.5
 
 .. _#1: https://github.com/RKrahl/datacite/pull/1
+.. _#2: https://github.com/RKrahl/datacite/pull/2
 
 
 0.1 (2022-11-25)

--- a/datacite/xml.py
+++ b/datacite/xml.py
@@ -26,8 +26,7 @@ class XML:
     def __init__(self, path):
         with path.open('rb') as f:
             self._etree = etree.parse(f)
-        if not self.XMLSchema().validate(self._etree):
-            raise ValueError("%s: invalid metadata." % path)
+        self.XMLSchema().assertValid(self._etree)
 
     @property
     def doi(self):

--- a/scripts/datacite-validate-xml.py
+++ b/scripts/datacite-validate-xml.py
@@ -1,0 +1,24 @@
+#! python
+
+import argparse
+import logging
+from pathlib import Path
+import sys
+from lxml.etree import DocumentInvalid
+import datacite.xml
+
+logging.basicConfig(level=logging.DEBUG, format="%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('metadata',
+                       help="XML file with DOI metadata",
+                       metavar="metadata.xml",
+                       type=Path)
+args = argparser.parse_args()
+
+try:
+    metadata = datacite.xml.XML(args.metadata)
+except DocumentInvalid as exc:
+    print("%s: %s" % (args.metadata, exc), file=sys.stderr)
+    sys.exit(2)

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     packages = ["datacite"],
-    scripts = ["scripts/datacite-doi.py"],
+    scripts = ["scripts/datacite-doi.py", "scripts/datacite-validate-xml.py"],
     python_requires = ">=3.4",
     install_requires = ["keyring", "lxml", "requests", "PyYAML"],
     cmdclass = dict(build_py=build_py, sdist=sdist, meta=meta),


### PR DESCRIPTION
- add a command line script `datacite-validate-xml.py` that takes a path to a XML file as argument and validates it against the current DataCite metadata schema.
- The constructor of `class datacite.xml.XML()` calls `XMLSchema().assertValid()` rather than  `XMLSchema().validate()`. As a result, `lxml.etree.DocumentInvalid` with a much more meaningful error message is raised in case of a validation error instead of `ValueError`.