### PR TITLE
Remove bulk create

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,11 +5,22 @@ Changelog
 0.3 (not yet released)
 ~~~~~~~~~~~~~~~~~~~~~~
 
+Incompatible changes
+--------------------
+
++ `#6`_, `#7`_: Remove subcommand `bulk-create` from `datacite-doi`
+  script.
+
+Bug fixes and minor changes
+---------------------------
+
 + `#4`_, `#5`_: Update the XML schema url for DataCite metadata to
   version 4.7.
 
 .. _#4: https://github.com/RKrahl/datacite/issues/4
 .. _#5: https://github.com/RKrahl/datacite/pull/5
+.. _#6: https://github.com/RKrahl/datacite/issues/6
+.. _#7: https://github.com/RKrahl/datacite/pull/7
 
 
 0.2 (2025-06-02)

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,6 @@ Required library packages:
 + `keyring`_
 + `lxml`_
 + `Requests`_
-+ `PyYAML`_
 
 Optional library packages:
 
@@ -58,6 +57,5 @@ permissions and limitations under the License.
 .. _keyring: https://pypi.org/project/keyring/
 .. _lxml: https://lxml.de/
 .. _Requests: https://requests.readthedocs.io/
-.. _PyYAML: https://github.com/yaml/pyyaml
 .. _setuptools_scm: https://github.com/pypa/setuptools_scm/
 .. _Apache License: https://www.apache.org/licenses/LICENSE-2.0

--- a/python-hzb-datacite.spec
+++ b/python-hzb-datacite.spec
@@ -20,7 +20,6 @@ BuildRequires:	    %{python_module setuptools}
 BuildRequires:	    fdupes
 BuildRequires:	    python-rpm-macros
 BuildRequires:	    update-alternatives
-Requires:	    python-PyYAML
 Requires:	    python-lxml
 Requires:	    python-requests
 Requires:	    python-keyring

--- a/scripts/datacite-doi.py
+++ b/scripts/datacite-doi.py
@@ -58,47 +58,6 @@ create_parser.add_argument('metadata',
 create_parser.set_defaults(func=create_doi)
 
 
-def bulk_create_doi(args):
-    config = datacite.config.get_config(args)
-    with args.control.open('rt') as f:
-        data = yaml.safe_load(f)
-    count = args.doi_start_count
-    for entry in data:
-        try:
-            if entry['ignore']:
-                continue
-        except KeyError:
-            pass
-        doi = Doi(entry['doi'] or (args.doi_format % count))
-        doi.url = entry['url']
-        metadata = datacite.xml.XML(Path(entry['metadata']))
-        metadata.doi = doi.doi
-        doi.metadata = metadata
-        log.info("Mint %s for %s", doi.doi, metadata.title)
-        if not args.dry_run:
-            doi.create(config)
-        count += 1
-
-bulk_create_parser = subparsers.add_parser('bulk-create',
-                                           help="Mint several DOIs")
-bulk_create_parser.add_argument('--dry-run',
-                                help=("show what would be done, "
-                                      "do not actually create any DOIs"),
-                                action='store_true')
-bulk_create_parser.add_argument('--doi-format',
-                                help=("DOI format string"),
-                                default='10.5442/NI%06d')
-bulk_create_parser.add_argument('--doi-start-count',
-                                help=("start value for the serial number in "
-                                      "the DOI"),
-                                type=int, default=1)
-bulk_create_parser.add_argument('control',
-                                help="control file",
-                                metavar="control.yaml",
-                                type=Path)
-bulk_create_parser.set_defaults(func=bulk_create_doi)
-
-
 def update_doi(args):
     config = datacite.config.get_config(args)
     doi = Doi(args.doi)

--- a/scripts/datacite-doi.py
+++ b/scripts/datacite-doi.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import logging
 from pathlib import Path
-import yaml
 import datacite.config
 from datacite.doi import Doi
 import datacite.xml

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,6 @@ setup(
     packages = ["datacite"],
     scripts = ["scripts/datacite-doi.py", "scripts/datacite-validate-xml.py"],
     python_requires = ">=3.4",
-    install_requires = ["keyring", "lxml", "requests", "PyYAML"],
+    install_requires = ["keyring", "lxml", "requests"],
     cmdclass = dict(build_py=build_py, sdist=sdist, meta=meta),
 )


### PR DESCRIPTION
Remove subcommand `bulk-create` from `datacite-doi` script. Close #6.