### PR TITLE
Add overview option to datacite-doi get

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 0.3 (not yet released)
 ~~~~~~~~~~~~~~~~~~~~~~
 
+New features
+------------
+
++ `#8`_, `#9`_: Add an `overview` option to `datacite-doi get`.
+
 Incompatible changes
 --------------------
 
@@ -21,6 +26,8 @@ Bug fixes and minor changes
 .. _#5: https://github.com/RKrahl/datacite/pull/5
 .. _#6: https://github.com/RKrahl/datacite/issues/6
 .. _#7: https://github.com/RKrahl/datacite/pull/7
+.. _#8: https://github.com/RKrahl/datacite/issues/8
+.. _#9: https://github.com/RKrahl/datacite/pull/9
 
 
 0.2 (2025-06-02)

--- a/datacite/doi.py
+++ b/datacite/doi.py
@@ -39,6 +39,13 @@ class Doi:
         return self._data['data']['attributes']
 
     @property
+    def state(self):
+        try:
+            return self._data['data']['attributes']['state']
+        except (TypeError, KeyError):
+            return None
+
+    @property
     def url(self):
         try:
             return self._data['data']['attributes']['url']

--- a/scripts/datacite-doi.py
+++ b/scripts/datacite-doi.py
@@ -20,7 +20,11 @@ def get_metadata(args):
     config = datacite.config.get_config(args, login=False)
     doi = Doi(args.doi)
     doi.fetch(config)
-    if args.show == 'metadata_xml':
+    if args.show == 'overview':
+        print("DOI: %s" % doi.doi)
+        print("State: %s" % doi.state)
+        print("URL: %s" % doi.url)
+    elif args.show == 'metadata_xml':
         print(doi.metadata)
     elif args.show == 'attributes':
         print(json.dumps(doi.attributes, indent=2))
@@ -31,8 +35,9 @@ def get_metadata(args):
 get_metadata_parser = subparsers.add_parser('get', help="Query a DOI")
 get_metadata_parser.add_argument('--show',
                                  help="select the kind of information to show",
-                                 choices=['metadata_xml', 'attributes'],
-                                 default='metadata_xml')
+                                 choices=['overview',
+                                          'metadata_xml', 'attributes'],
+                                 default='overview')
 get_metadata_parser.add_argument('doi', help="the DOI to search")
 get_metadata_parser.set_defaults(func=get_metadata)
 


### PR DESCRIPTION
Add an option `overview` to the `--show` argument in `datacite-doi get`. If selected, the script will show a short overview (DOI, State, and URL). The new option is the default. Close #8.