### PR TITLE
Add a new config option: keyring_system

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ New features
 
 + `#8`_, `#9`_: Add an `overview` option to `datacite-doi get`.
 
++ `#15`_, `#16`_: Add a new config option `keyring_system` for the
+  system name to be used when trying to fetch the password from the
+  keyring.
+
 Incompatible changes
 --------------------
 
@@ -41,6 +45,8 @@ Bug fixes and minor changes
 .. _#12: https://github.com/RKrahl/datacite/pull/12
 .. _#13: https://github.com/RKrahl/datacite/issues/13
 .. _#14: https://github.com/RKrahl/datacite/pull/14
+.. _#15: https://github.com/RKrahl/datacite/issues/15
+.. _#16: https://github.com/RKrahl/datacite/pull/16
 
 
 0.2 (2025-06-02)

--- a/datacite/config.py
+++ b/datacite/config.py
@@ -18,7 +18,7 @@ cfgfname = "datacite.cfg"
 
 def _get_password(config):
     if config.keyring:
-        p = keyring.get_password("DataCite", config.username)
+        p = keyring.get_password(config.keyring_system, config.username)
         if p is not None:
             return p
     return getpass.getpass()
@@ -61,6 +61,8 @@ def add_cli_arguments(argparser, *, login=True):
                                action='store_const', const=False,
                                help="do not try to get the password from the "
                                "system keyring service")
+        argparser.add_argument('--keyring-system',
+                               help="system name to use in the keyring")
 
 def get_config(args=None, *, login=True, **kwargs):
 
@@ -74,7 +76,7 @@ def get_config(args=None, *, login=True, **kwargs):
 
     if login:
         opts = ['configfile', 'configsection', 'apiurl',
-                'keyring', 'username', 'password']
+                'keyring', 'keyring_system', 'username', 'password']
     else:
         opts = ['configfile', 'configsection', 'apiurl']
     config = Configuration(opts)
@@ -113,6 +115,9 @@ def get_config(args=None, *, login=True, **kwargs):
                 continue
         if opt == 'keyring':
             setattr(config, opt, True)
+            continue
+        if opt == 'keyring_system':
+            setattr(config, opt, "DataCite")
             continue
         if opt == 'password':
             setattr(config, opt, _get_password(config))


### PR DESCRIPTION
Add a new config option: `keyring_system`, the system name to be used when trying to fetch the password from the keyring.

This config option can either be set in the config file or in the command line (as `--keyring-system`). It defaults to `"DataCite"`, which is the value that was hard coded before.

Close #15.